### PR TITLE
Fixes to work in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 sudo: false
 dist: trusty
 install: pip install numpy scipy matplotlib pandas seaborn scikit_learn requests pytest

--- a/msda/batch_normalization.py
+++ b/msda/batch_normalization.py
@@ -27,7 +27,7 @@ def normalize_within_batch(df, samples, control='Bridge'):
     for sample in true_samples:
         sample_mean = float(df.loc[:, sample].sum())
         nrm = bridge_mean / sample_mean
-        # print nrm
+        # print(nrm)
         df_norm_intra.loc[:, sample] = nrm * df_norm_intra.loc[:, sample]
     return df_norm_intra
 
@@ -102,7 +102,7 @@ def normalize_per_protein(df, df_refs, samples, control='Bridge'):
         else:
             nrm = protein_in_refset / protein_in_set
         # index = df_pr[df_pr.Uniprot_Id == protein].index.values[0]
-        #  print protein, protein_in_set, protein_in_refset
+        #  print(protein, protein_in_set, protein_in_refset)
         df_pr.loc[protein, samples] = nrm * df_pr.loc[protein, samples]
     return df_pr
 

--- a/msda/clustering.py
+++ b/msda/clustering.py
@@ -80,7 +80,7 @@ def plot_pca(X_pca, explained_variance, samples,
     if not labels:
         plt.scatter(Xs_pca[:, 0], Xs_pca[:, 1], alpha=0.5, s=20)
     elif labels:
-        for lab, col in labels.iteritems():
+        for lab, col in labels.items():
             plt.scatter(Xs_pca[y == lab, 0], Xs_pca[y == lab, 1],
                         label=lab, color=col)
     # texts = []

--- a/msda/enrichr_client.py
+++ b/msda/enrichr_client.py
@@ -40,5 +40,5 @@ def get_enrichment_result(data, library='KEGG_2015'):
         df = pd.DataFrame(body, columns=header)
         return df
     except AssertionError:
-        print data['job_name']
+        print(data['job_name'])
      #return df

--- a/msda/phospho_network.py
+++ b/msda/phospho_network.py
@@ -307,7 +307,7 @@ def construct_table(df_nt, dfc):
     df_clean = dfc.copy()
     df_clean.Motif = [m[1:-1] for m in df_clean.Motif.tolist()]
     df_psp = dfk[dfk['SITE_+/-7_AA'].isin(df_clean.Motif.tolist())]
-    print df_psp.head()
+    print(df_psp.head())
     df_psp = df_psp[df_psp.SUB_ACC_ID.isin(df_clean.Uniprot_Id.tolist())]
     df_psp['SUBSTRATE'] = [mapping.get_name_from_uniprot(id)
                            for id in df_psp.SUB_ACC_ID.tolist()]
@@ -356,8 +356,8 @@ def generate_kinase_annotations(df, path2data):
 
     # run networkin prediction
     run_networkin(fasfile, resfile, outfile)
-    print "Running networkin algorithm. This may take 2+ hours"
-    print "----------------------------------------------------"
+    print("Running networkin algorithm. This may take 2+ hours")
+    print("----------------------------------------------------")
 
     df_nt = pd.read_table(outfile)
     df_nt = df_nt[df_nt['NetworKIN score'] >= 1]

--- a/msda/phospho_network.py
+++ b/msda/phospho_network.py
@@ -4,7 +4,7 @@ import requests
 import numpy as np
 import re
 import subprocess
-import mapping
+from msda import mapping
 import os
 from msda import ptm_info as pi
 from msda import preprocessing as pr

--- a/msda/preprocessing.py
+++ b/msda/preprocessing.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import re
-from mapping import get_name_from_uniprot
+from msda.mapping import get_name_from_uniprot
 import numpy as np
-import batch_normalization as bn
+import msda.batch_normalization as bn
 import os
 from msda import process_raw
 

--- a/msda/pride_client.py
+++ b/msda/pride_client.py
@@ -19,7 +19,7 @@ def get_peptides(uniprot_id):
     projects = get_project_accession(uniprot_id)
     peptides = []
     for i, project in enumerate(projects):
-        print " processing project %s: %s..." % (i+1, project)
+        print(" processing project %s: %s..." % (i+1, project))
         assay_list = get_assay_accession(uniprot_id, project)
         for assay in assay_list:
             peptides += get_peptide_sequence(assay)

--- a/msda/ptm_info.py
+++ b/msda/ptm_info.py
@@ -241,7 +241,7 @@ def construct_motif(uid, site):
             subseq = 'obsolete'
         return subseq
     except UnicodeEncodeError:
-        print uid, site
+        print(uid, site)
         subseq = 'obsolote'
         return subseq
 
@@ -261,7 +261,7 @@ def get_seq(uid):
         seq_all = str(r.text)
         seq = ''.join(seq_all.strip().split('\n')[1:])
     except UnicodeEncodeError:
-        print uid
+        print(uid)
         seq = 'unknown'
     return seq
 

--- a/msda/subset.py
+++ b/msda/subset.py
@@ -113,7 +113,7 @@ def pfam_report(file):
         try:
             domain = get_pfam_domain(p, s)
         except IndexError:
-            print p, s
+            print(p, s)
         acc.append(domain[0])
         id.append(domain[1])
         start.append(domain[2])
@@ -176,7 +176,7 @@ def get_id(id, db_from, db_to='ACC'):
     try:
         name = re.split('\_', df.To[0])[0]
     except IndexError:
-        # print refseq
+        # print(refseq)
         name = 'not found'
     return name
 

--- a/msda/ups2_calibration.py
+++ b/msda/ups2_calibration.py
@@ -39,7 +39,7 @@ def get_id(md_string):
         id = md_string.strip().split('|')[1]
     except IndexError:
         id = md_string
-        print id
+        print(id)
     return id
 
 
@@ -65,7 +65,7 @@ def get_mw(seq):
                                                  == aa].values[0]
             mw_seq += mw_aa * counter[aa]
         except IndexError:
-            print aa
+            print(aa)
     mw_seq -= 18.015 * (len(seq) - 1)
     mw_seq = mw_seq * 0.001
     return mw_seq
@@ -379,7 +379,7 @@ def ibaq_comparision(df_ibaq, samples, biomarkers,
         for id in range(len(df3)):
             sample = df3['variable'].iloc[id]
             labels.append(sample_map[sample])
-        print len(labels)    
+        print(len(labels))    
         df3['Label'] = labels        
     #sns.stripplot(x="Gene_Symbol", y="log10(iBAQ)",
     #              data=df3, hue="Label")

--- a/msda/verify_tomahaq_peptides.py
+++ b/msda/verify_tomahaq_peptides.py
@@ -1,6 +1,6 @@
 import re
 import pandas as pd
-import phosphosite_client as pc
+import msda.phosphosite_client as pc
 import requests
 
 


### PR DESCRIPTION
This PR updates some import paths to refer to `msda` explicitly, adds parentheses around prints, and changes iteritems to items to make `msda` work in Python 3 (while maintaining Python 2 compatibility). Further changes may be needed.