### PR TITLE
Scale value argument to scale function

### DIFF
--- a/msda/preprocessing.py
+++ b/msda/preprocessing.py
@@ -221,14 +221,14 @@ def rename_bridge(df, batch_num):
     return df
 
 
-def merge_batches(dflist, meta_df, pMS=False, norm=False):
+def merge_batches(dflist, meta_df, pMS=False, norm=False, scale_value=100):
     df_list = []
     for df in dflist:
         # df = pd_import(file)
         if not pMS:
             df = df.drop_duplicates(['Uniprot_Id'])
         df, samples = rename_labels(df, meta_df, pMS)
-        df_scaled = process_raw.scale(df, samples)
+        df_scaled = process_raw.scale(df, samples, scale_value)
         # df.index = df.Uniprot_Id.tolist()
         # df = strip_metadata(df, samples)
         df_list.append(df_scaled)
@@ -321,12 +321,12 @@ def merge_duplicate_features(df):
     return df2
 
 
-def normalize_pMS_by_protein(dfp, dfm, samples):
+def normalize_pMS_by_protein(dfp, dfm, samples, scale_value=100):
     dfp.index = dfp['Uniprot_Id'].tolist()
     dfm.index = dfm['Uniprot_Id'].tolist()
     dfm = dfm.loc[dfp.index.tolist()]
     dfpn = dfp.copy()
     dfpn[samples] = dfpn[samples].div(dfm[samples])
     dfpn = dfpn.replace([np.inf], np.nan).dropna()
-    dfpn_scaled = process_raw.scale(dfpn, samples)
+    dfpn_scaled = process_raw.scale(dfpn, samples, scale_value)
     return dfpn_scaled

--- a/msda/process_raw.py
+++ b/msda/process_raw.py
@@ -50,9 +50,25 @@ def normalize(df, nrm_list):
     return df2
 
 
-def scale(df, samples):
+def scale(df, samples, norm_value=100):
+    """Return copy of dataframe with a set of columns normalized
+
+    Parameters
+    ----------
+    df : pandas dataframe
+        The data frame to be normalized
+    samples : list of str
+        Column identifiers to use for indexing the data frame
+    norm_value : Optional[float]
+        The value to normalize the selected samples to, default: 100
+
+    Returns
+    -------
+    df2 : pandas dataframe
+        The data frame with the given columns normalized to the given value
+    """
     df2 = df.copy()
     df2[samples] = df2[samples].div(df2[samples].sum(axis=1),
                                     axis=0)
-    df2[samples] = df2[samples].multiply(100)
+    df2[samples] = df2[samples].multiply(norm_value)
     return df2

--- a/msda/process_raw.py
+++ b/msda/process_raw.py
@@ -50,7 +50,7 @@ def normalize(df, nrm_list):
     return df2
 
 
-def scale(df, samples, norm_value=100):
+def scale(df, samples, scale_value=100):
     """Return copy of dataframe with a set of columns normalized
 
     Parameters
@@ -59,7 +59,7 @@ def scale(df, samples, norm_value=100):
         The data frame to be normalized
     samples : list of str
         Column identifiers to use for indexing the data frame
-    norm_value : Optional[float]
+    scale_value : Optional[float]
         The value to normalize the selected samples to, default: 100
 
     Returns
@@ -70,5 +70,5 @@ def scale(df, samples, norm_value=100):
     df2 = df.copy()
     df2[samples] = df2[samples].div(df2[samples].sum(axis=1),
                                     axis=0)
-    df2[samples] = df2[samples].multiply(norm_value)
+    df2[samples] = df2[samples].multiply(scale_value)
     return df2


### PR DESCRIPTION
This PR adds an extra argument to the `scale` function to allow scaling to values other than 100 (which remains as the default so old code doesn't need to be updated). It also documents the `scale` function.